### PR TITLE
feat: improve tp8 display function

### DIFF
--- a/TP/TP8_puissance_4/TP8_affichage.ml
+++ b/TP/TP8_puissance_4/TP8_affichage.ml
@@ -5,13 +5,13 @@ type puissance4 = {grille : int array array;
 
 let afficher jeu =
     let open Printf in
-    let symb = [|"_"; "X̲"; "O̲"|] in
-    print_string " _ _ _ _ _ _ _\n"; 
+    let symb = [|"\x1b[34m\x1b[4m \x1b[0m"; "\x1b[31m\x1b[4m●\x1b[0m"; "\x1b[33m\x1b[4m●\x1b[0m"|] in
+    print_string "\x1b[34m _ _ _ _ _ _ _\x1b[0m\n";
     for i = 0 to 5 do
-        print_string "|";
+        print_string "\x1b[34m|\x1b[0m";
         for j = 0 to 6 do
-            printf "%s|" symb.(jeu.grille.(i).(j))
+            printf "%s\x1b[34m|\x1b[0m" symb.(jeu.grille.(i).(j))
         done;
         print_newline ();
     done;
-    print_string " 0 1 2 3 4 5 6\n";;   
+    print_string "\x1b[34m\x1b[1m 0 1 2 3 4 5 6\x1b[0m\n";;


### PR DESCRIPTION
Petite modification visuelle de la fonction afficher du tp 8, voici un exemple après un appel à `afficher p4` : 

![image](https://github.com/user-attachments/assets/1f8e85f2-9f7e-45c9-a61b-f458178749cc)

Les codes proviennent de [colorsh](https://codeberg.org/gurvan/colorsh/src/branch/main/colorsh/colorsh.ml) (et sont valides sur tous les `stdout`)